### PR TITLE
Update Vite scripts to use explicit node paths

### DIFF
--- a/frontend/node_modules/.package-lock.json
+++ b/frontend/node_modules/.package-lock.json
@@ -313,6 +313,23 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/win32-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
@@ -581,6 +598,34 @@
       "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.48.1.tgz",
+      "integrity": "sha512-90taWXCWxTbClWuMZD0DKYohY1EovA+W5iytpE89oUPmT5O1HFdf8cuuVIylE6vCbrGdIGv85lVRzTcpTRZ+kA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.48.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.48.1.tgz",
+      "integrity": "sha512-2Gu29SkFh1FfTRuN1GR1afMuND2GKzlORQUP3mNMJbqdndOg7gNsa81JnORctazHRokiDzQ5+MLE5XYmZW5VWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.48.1",

--- a/frontend/node_modules/.vite/deps/_metadata.json
+++ b/frontend/node_modules/.vite/deps/_metadata.json
@@ -1,55 +1,55 @@
 {
-  "hash": "654b3387",
-  "configHash": "c84719bc",
-  "lockfileHash": "6c3acc7b",
-  "browserHash": "dd087aeb",
+  "hash": "e40fc1a7",
+  "configHash": "80cd3923",
+  "lockfileHash": "582959cf",
+  "browserHash": "cacc13cd",
   "optimized": {
     "react": {
       "src": "../../react/index.js",
       "file": "react.js",
-      "fileHash": "21f6fae3",
+      "fileHash": "057e579e",
       "needsInterop": true
     },
     "react-dom": {
       "src": "../../react-dom/index.js",
       "file": "react-dom.js",
-      "fileHash": "ecf44689",
+      "fileHash": "65c61058",
       "needsInterop": true
     },
     "react/jsx-dev-runtime": {
       "src": "../../react/jsx-dev-runtime.js",
       "file": "react_jsx-dev-runtime.js",
-      "fileHash": "cbaa1f0a",
+      "fileHash": "a56871fc",
       "needsInterop": true
     },
     "react/jsx-runtime": {
       "src": "../../react/jsx-runtime.js",
       "file": "react_jsx-runtime.js",
-      "fileHash": "3461ac5e",
+      "fileHash": "67b7eae5",
       "needsInterop": true
     },
     "axios": {
       "src": "../../axios/index.js",
       "file": "axios.js",
-      "fileHash": "03dc8c6d",
+      "fileHash": "ce290302",
       "needsInterop": false
     },
     "lucide-react": {
       "src": "../../lucide-react/dist/esm/lucide-react.js",
       "file": "lucide-react.js",
-      "fileHash": "7b709ff4",
+      "fileHash": "b34a04ab",
       "needsInterop": false
     },
     "react-dom/client": {
       "src": "../../react-dom/client.js",
       "file": "react-dom_client.js",
-      "fileHash": "6eda8972",
+      "fileHash": "ffefc4fc",
       "needsInterop": true
     },
     "react-router-dom": {
       "src": "../../react-router-dom/dist/index.js",
       "file": "react-router-dom.js",
-      "fileHash": "23833549",
+      "fileHash": "d13a818b",
       "needsInterop": false
     }
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,10 +4,10 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --port 3000 --host 0.0.0.0",
-    "build": "vite build",
+    "dev": "node ./node_modules/vite/bin/vite.js --port 3000 --host 0.0.0.0",
+    "build": "node ./node_modules/vite/bin/vite.js build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview --port 3000 --host 0.0.0.0"
+    "preview": "node ./node_modules/vite/bin/vite.js preview --port 3000 --host 0.0.0.0"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Changes Made

### Package Scripts Update
- Modified `dev`, `build`, and `preview` scripts in `package.json` to use explicit node paths
- Changed from `vite` to `node ./node_modules/vite/bin/vite.js` for all Vite commands

### Dependency Updates
- Added new Linux x64 platform-specific dependencies:
  - `@esbuild/linux-x64` version 0.21.5
  - `@rollup/rollup-linux-x64-gnu` version 4.48.1  
  - `@rollup/rollup-linux-x64-musl` version 4.48.1

### Build Cache Updates
- Updated Vite dependency metadata with new hash values
- Refreshed file hashes for optimized dependencies including React, React DOM, Axios, Lucide React, and React Router DOMTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e5896fa660e446c9b1139a387fded101/pixel-sanctuary)

👀 [Preview Link](https://e5896fa660e446c9b1139a387fded101-pixel-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e5896fa660e446c9b1139a387fded101</projectId>-->
<!--<branchName>pixel-sanctuary</branchName>-->